### PR TITLE
Fix depth slider and item load errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,8 +29,14 @@ const REFERENCES = [
 ];
 
 async function loadData(){
-  const res = await fetch('data/species.json');
-  items = await res.json();
+  try{
+    const res = await fetch('data/species.json');
+    if(!res.ok) throw new Error('Request failed');
+    items = await res.json();
+  }catch(err){
+    console.error('Failed to load species data', err);
+    items = [];
+  }
 }
 
 function clamp(v,min,max){ return Math.min(max, Math.max(min, v)); }
@@ -133,10 +139,15 @@ async function init(){
   // Pointer events unify mouse and touch
   function startPointerDrag(ev){
     ev.preventDefault();
-    handle.setPointerCapture(ev.pointerId);
+    const capturer = ev.target;
+    if(capturer.setPointerCapture){
+      try{ capturer.setPointerCapture(ev.pointerId); }catch{}
+    }
     const move = e => setFromClientY(e.clientY);
     const stop = e => {
-      handle.releasePointerCapture(ev.pointerId);
+      if(capturer.releasePointerCapture){
+        try{ capturer.releasePointerCapture(ev.pointerId); }catch{}
+      }
       window.removeEventListener('pointermove', move);
       window.removeEventListener('pointerup', stop);
       window.removeEventListener('pointercancel', stop);

--- a/grid.js
+++ b/grid.js
@@ -1,6 +1,15 @@
 async function load(){
-  const res = await fetch('data/species.json');
-  const items = await res.json();
+  let items = [];
+  try{
+    const res = await fetch('data/species.json');
+    if(res.ok){
+      items = await res.json();
+    }else{
+      throw new Error('Request failed');
+    }
+  }catch(err){
+    console.error('Failed to load species data', err);
+  }
   const grid = document.getElementById('grid');
   const q = document.getElementById('q');
   const group = document.getElementById('group');

--- a/item.js
+++ b/item.js
@@ -2,9 +2,22 @@
 async function load(){
   const params = new URLSearchParams(location.search);
   const id = params.get('id');
-  const res = await fetch('data/species.json');
-  const items = await res.json();
+  let items = [];
+  try{
+    const res = await fetch('data/species.json');
+    if(res.ok){
+      items = await res.json();
+    }else{
+      throw new Error('Request failed');
+    }
+  }catch(err){
+    console.error('Failed to load species data', err);
+  }
   const item = items.find(x => x.id === id) || items[0];
+  if(!item){
+    document.getElementById('content').textContent = 'Species data unavailable.';
+    return;
+  }
   document.getElementById('title').textContent = item.common_name;
 
   const cacheKey = 'species_cache:' + id;


### PR DESCRIPTION
## Summary
- prevent crashes when species data fails to load by catching fetch errors
- ensure depth slider works when dragging the track by guarding pointer capture

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b22cea87483298fa4fcfb9196522b