### PR TITLE
Fix depth slider handle interaction

### DIFF
--- a/app.js
+++ b/app.js
@@ -160,10 +160,15 @@ async function init(){
 
   // Click or drag anywhere on the track
   track.addEventListener('pointerdown', e => {
+    if(e.target !== track) return; // ignore handle to keep focus
     e.preventDefault();
     startPointerDrag(e);
   });
-  handle.addEventListener('pointerdown', startPointerDrag);
+  handle.addEventListener('pointerdown', e => {
+    e.preventDefault();
+    handle.focus();
+    startPointerDrag(e);
+  });
 
   // Keyboard support
   handle.addEventListener('keydown', e => {


### PR DESCRIPTION
## Summary
- Prevent track from intercepting pointer events when the handle is clicked
- Focus the handle on pointer down to restore keyboard navigation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b263ddcac8329829ba6617ffa5b65